### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ line of a file is a much heavier task than printing a match at the first line of
 Since `syntect` printer is designed for calculating syntax highlights per file in parallel, its performance is much better. It's
 2x~4x faster than `bat` printer in some experiments. More match results get better performance.
 
-In contrast, bat is not designed for multi-threads. It's not possible to share `bat::PrettyPrinter` instance accross threads. It
+In contrast, bat is not designed for multi-threads. It's not possible to share `bat::PrettyPrinter` instance across threads. It
 means that printing match results including syntax highlighting must be done in a single thread.
 
 | `syntect` printer sequence | `bat` printer sequence |
@@ -237,7 +237,7 @@ option. To know names of themes, try `--list-themes` flag.
 hgrep --theme Nord ...
 ```
 
-The default layout is 'grid'. To reduce borderlines to use space more efficiantly, `--no-grid` option is available.
+The default layout is 'grid'. To reduce borderlines to use space more efficiently, `--no-grid` option is available.
 
 ```sh
 hgrep --no-grid ...

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,19 +403,19 @@ fn build_ripgrep_config(
     if let Some(size) = matches.get_one::<String>("max-filesize") {
         config
             .max_filesize(size)
-            .context("coult not parse --max-filesize option value as file size string")?;
+            .context("could not parse --max-filesize option value as file size string")?;
     }
 
     if let Some(limit) = matches.get_one::<String>("regex-size-limit") {
         config
             .regex_size_limit(limit)
-            .context("coult not parse --regex-size-limit option value as size string")?;
+            .context("could not parse --regex-size-limit option value as size string")?;
     }
 
     if let Some(limit) = matches.get_one::<String>("dfa-size-limit") {
         config
             .dfa_size_limit(limit)
-            .context("coult not parse --dfa-size-limit option value as size string")?;
+            .context("could not parse --dfa-size-limit option value as size string")?;
     }
 
     let types = matches.get_many::<String>("type");

--- a/src/syntect.rs
+++ b/src/syntect.rs
@@ -189,7 +189,7 @@ impl<'a, 'line: 'a> DrawEvents<'a, 'line> {
         match self.regions.first().copied() {
             Some((s, e)) if o == s && o < e => RegionBoundary::Start,
             Some((_, e)) if o == e => {
-                // When the next region is adjcent, skip changing highlight
+                // When the next region is adjacent, skip changing highlight
                 match self.regions.get(1) {
                     Some((s, _)) if o == *s => RegionBoundary::NotFound,
                     _ => RegionBoundary::End,


### PR DESCRIPTION
Found via `codespell -S target -L crate,fo`

Not sure if you want to update `accross` -> `across`?

```sh
$ typos --format brief
./CHANGELOG.md:56:100: `Matrial` -> `Martial`
./testdata/syntect/wrap_region_jp_accross_line.out:15: `accross` -> `across`
./testdata/syntect/wrap_whole_3_lines.rs:3:31: `fo` -> `of`, `for`
./testdata/syntect/wrap_regions_japanese.rs:4:50: `fo` -> `of`, `for`
./testdata/syntect/wrap_region_accross_line.rs:12: `accross` -> `across`
./testdata/syntect/wrap_region_accross_line.out:12: `accross` -> `across`
./testdata/syntect/wrap_region_jp_accross_line.rs:15: `accross` -> `across`
./testdata/syntect/wrap_whole_3_lines.out:6:137: `fo` -> `of`, `for`
./testdata/syntect/wrap_accross_regions.out:5: `accross` -> `across`
./testdata/syntect/wrap_accross_regions.rs:5: `accross` -> `across`
./testdata/syntect/wrap_regions_japanese.out:8:356: `fo` -> `of`, `for`
./src/ripgrep.rs:942:15: `accross` -> `across`
./src/ripgrep.rs:947:16: `accross` -> `across`
./src/syntect.rs:1403:22: `accross` -> `across`
./src/syntect.rs:1405:29: `accross` -> `across`
./src/syntect.rs:1406:32: `accross` -> `across`
```